### PR TITLE
Sanitize caryear in the !drives command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Intellij
+.idea

--- a/cogs/cars.py
+++ b/cogs/cars.py
@@ -378,8 +378,14 @@ class Cars(commands.Cog):
             carmiles = row[5]
 
             user = await self.bot.fetch_user(UserID)
+            title = ''.join(user.name) + "'s "
+            if caryear is not None:
+                caryear = caryear.replace('!carsetup', '')
+                if caryear not in carmake:
+                    title += ''.join(caryear.strip()) + " "
+            title += ''.join(carmake)
             embed = discord.Embed(
-                title=''.join(user.name) + "'s " + ''.join(caryear) + " " + ''.join(carmake),
+                title=title,
                 color=0xFFD414
             )
 


### PR DESCRIPTION
The caryear is sometimes missing, causing a TypeError.
Some data also contains mistakes such as "!carsetup" or duplicate
year/name. Sanitize data before embedding it.